### PR TITLE
* fix build under MSVC

### DIFF
--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -8,6 +8,11 @@
 #include "chunks.h"
 #include "commands.h"
 
+#ifdef QHEXEDIT_EXPORTS
+#define QHEXEDIT_API Q_DECL_EXPORT
+#else
+#define QHEXEDIT_API Q_DECL_IMPORT
+#endif
 /** \mainpage
 QHexEdit is a binary editor widget for Qt.
 
@@ -48,7 +53,7 @@ QHexEdit is based on QIODevice, that's why QHexEdit can handle big amounts of
 data. The size of edited data can be more then two gigabytes without any
 restrictions.
 */
-class QHexEdit : public QAbstractScrollArea
+class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
 {
     Q_OBJECT
 

--- a/src/qhexedit.pro
+++ b/src/qhexedit.pro
@@ -1,11 +1,12 @@
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
+QT         += core gui
 TEMPLATE    = lib
 
 VERSION     = 3.0.0
 
-CONFIG      += qt warn_on release
+DEFINES += QHEXEDIT_EXPORTS
 
 HEADERS     = \
     qhexedit.h \
@@ -18,6 +19,7 @@ SOURCES     = \
     chunks.cpp \
     commands.cpp
 
-TARGET      = qhexedit
+Release:TARGET = qhexedit
+Debug:TARGET = qhexeditd
 
-DESTDIR     = /usr/lib
+DESTDIR = ../lib


### PR DESCRIPTION
* change the library directory to local one. because the local library have to be installed with separated command
+ build under MSVC the .dll file and concerning .lib to make it successful use in other MSVC applications
+ change the target name for debug with appendix "d" (Qt like style for release and debug libraries)