### PR TITLE
Fix lost focus

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -909,10 +909,10 @@ void QHexEdit::resizeEvent(QResizeEvent *)
 }
 
 bool QHexEdit::focusNextPrevChild(bool next){
-    if ( (next && _editAreaIsAscii) || (!next && !_editAreaIsAscii ))
-            return true;
+    if ((next && _editAreaIsAscii) || (!next && !_editAreaIsAscii))
+        return QWidget::focusNextPrevChild(next);
     else
-            return false;
+        return false;
 }
 
 // ********************************************************************** Handle selections


### PR DESCRIPTION
please apply this fix. otherwise in your version qhexedit can't lost(give up) focus to other widgets.

the idea was:
1. tab switched from hex to ascii
2. shift tab switched from ascii to hex
3. tab in ascii area allows to switch focus to the next child widget 
4. shift-tab in hex area allows to switch focus to previous child widget 

the return value true don't switch the focus ;-)
