### PR TITLE
Fix integer constant is too large compiler error

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -172,7 +172,7 @@ void QHexEdit::setCursorPosition(qint64 position)
     if (_editAreaIsAscii)
     {
         _pxCursorX = x / 2 * _pxCharWidth + _pxPosAsciiX;
-        _cursorPosition = position & 0xFFFFFFFFFFFFFFFE;
+        _cursorPosition = position & 0xFFFFFFFFFFFFFFFELL;
     } else {
         _pxCursorX = (((x / 2) * 3) + (x % 2)) * _pxCharWidth + _pxPosHexX;
         _cursorPosition = position;


### PR DESCRIPTION
I'm getting the following error with g++ 3.4.2 on 32-bit Windows -

qhexedit.cpp: In member function `void QHexEdit::setCursorPosition(qint64)':
qhexedit.cpp:175: error: integer constant is too large for "long" type
mingw32-make[1]: *** [debug/qhexedit.o] Error 1
mingw32-make: *** [debug] Error 2

Admittedly I'm using a really old compiler version - g++ 3.4.2