### PR TITLE
Fix cursor display in ReadOnly mode.

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -910,22 +910,28 @@ void QHexEdit::paintEvent(QPaintEvent *event)
         painter.setPen(viewport()->palette().color(QPalette::WindowText));
     }
 
-    // paint cursor
-    if (_blink && !_readOnly && hasFocus())
-        painter.fillRect(_cursorRect, this->palette().color(QPalette::WindowText));
-    else
+    int asciiPositionInShowData = _cursorPosition / 2 - _bPosFirst;
+
+    // due to scrolling the cursor can go out of the currently displayed data
+    if ((asciiPositionInShowData >= 0) && (asciiPositionInShowData < _dataShown.size()))
     {
-        painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight, _pxCharWidth, _pxCharHeight), viewport()->palette().color(QPalette::Base));
-        if (_editAreaIsAscii) {
-            QByteArray ba = _dataShown.mid((_cursorPosition - _bPosFirst) / 2, 1);
-            if (ba != "")
+        // paint cursor
+        if (_blink && !_readOnly && hasFocus())
+            painter.fillRect(_cursorRect, this->palette().color(QPalette::WindowText));
+        else
+        {
+            painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), viewport()->palette().color(QPalette::Base));
+            if (_editAreaIsAscii)
             {
-                if (ba.at(0) <= ' ')
-                    ba[0] = '.';
-                painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, ba);
+                int ch = (uchar)_dataShown.at(asciiPositionInShowData);
+                if ( ch < 0x20 )
+                    ch = '.';
+                painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, QChar(ch));
             }
-        } else {
-            painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, _hexDataShown.mid(_cursorPosition - _bPosFirst, 1));
+            else
+            {
+                painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, _hexDataShown.mid(2 * asciiPositionInShowData, 1));
+            }
         }
     }
 

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -923,7 +923,9 @@ void QHexEdit::paintEvent(QPaintEvent *event)
         // paint cursor
         if (_readOnly)
         {
-            painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), viewport()->palette().color(QPalette::Base));
+            // make the background stick out
+            QColor color = viewport()->palette().dark().color();
+            painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), color);
             if (_editAreaIsAscii)
             {
                 // every 2 hex there is 1 ascii

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -43,7 +43,7 @@ QHexEdit::QHexEdit(QWidget *parent) : QAbstractScrollArea(parent)
     connect(_undoStack, SIGNAL(indexChanged(int)), this, SLOT(dataChangedPrivate(int)));
 
     _cursorTimer.setInterval(500);
-    _cursorTimer.start();
+    // the timer is started inside setReadOnly() if necessary
 
     setAddressWidth(4);
     setAddressArea(true);
@@ -285,6 +285,10 @@ bool QHexEdit::isReadOnly()
 void QHexEdit::setReadOnly(bool readOnly)
 {
     _readOnly = readOnly;
+    if (_readOnly)
+        _cursorTimer.stop();
+    else
+        _cursorTimer.start();
 }
 
 void QHexEdit::setHexCaps(const bool isCaps)
@@ -917,9 +921,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
     if ((hexPositionInShowData >= 0) && (hexPositionInShowData < _hexDataShown.size()))
     {
         // paint cursor
-        if (_blink && !_readOnly && hasFocus())
-            painter.fillRect(_cursorRect, this->palette().color(QPalette::WindowText));
-        else
+        if (_readOnly)
         {
             painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), viewport()->palette().color(QPalette::Base));
             if (_editAreaIsAscii)
@@ -935,6 +937,11 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             {
                 painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, _hexDataShown.mid(hexPositionInShowData, 1));
             }
+        }
+        else
+        {
+            if (_blink && hasFocus())
+                painter.fillRect(_cursorRect, this->palette().color(QPalette::WindowText));
         }
     }
 

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -910,10 +910,11 @@ void QHexEdit::paintEvent(QPaintEvent *event)
         painter.setPen(viewport()->palette().color(QPalette::WindowText));
     }
 
-    int asciiPositionInShowData = _cursorPosition / 2 - _bPosFirst;
+    // _cursorPosition counts in 2, _bPosFirst counts in 1
+    int hexPositionInShowData = _cursorPosition - 2 * _bPosFirst;
 
     // due to scrolling the cursor can go out of the currently displayed data
-    if ((asciiPositionInShowData >= 0) && (asciiPositionInShowData < _dataShown.size()))
+    if ((hexPositionInShowData >= 0) && (hexPositionInShowData < _hexDataShown.size()))
     {
         // paint cursor
         if (_blink && !_readOnly && hasFocus())
@@ -923,6 +924,8 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), viewport()->palette().color(QPalette::Base));
             if (_editAreaIsAscii)
             {
+                // every 2 hex there is 1 ascii
+                int asciiPositionInShowData = hexPositionInShowData / 2;
                 int ch = (uchar)_dataShown.at(asciiPositionInShowData);
                 if ( ch < 0x20 )
                     ch = '.';
@@ -930,7 +933,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             }
             else
             {
-                painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, _hexDataShown.mid(2 * asciiPositionInShowData, 1));
+                painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, _hexDataShown.mid(hexPositionInShowData, 1));
             }
         }
     }


### PR DESCRIPTION
1) do not display cursor if outside displayed area (if can happen with scrolling)
2) index arithmetic was wrong
3) take into account _pxSelectionSub when filling the rectangle
4) draw ascii with the same logic at line 899-904

Now it works, but due to the fact that the cursor background is painted with viewport()->palette().color(QPalette::Base). The cursor is actually invisible. I tested this patch with a yellow background.


Signed-off-by: Andrea Odetti <mariofutire@gmail.com>