### PR TITLE
Fixed OSX build, initial pkgconfig support

### DIFF
--- a/build-python-bindings.sh
+++ b/build-python-bindings.sh
@@ -4,7 +4,8 @@ cd build
 # /usr/share/qt4/bin/qmake ../src/qhexedit.pro
 
 # for Qt5 use qt5-qmake
-/usr/lib/x86_64-linux-gnu/qt5/bin/qmake ../src/qhexedit.pro
+#/usr/lib/x86_64-linux-gnu/qt5/bin/
+qmake ../src/qhexedit.pro
 
 sudo make
 cd ..
@@ -13,4 +14,5 @@ cd ..
 # sudo python2 setup.py install
 
 # for PyQt5 use python3 and PyQt5
-sudo python3 setup.py install
+[ -z "$PKG_CONFIG_PATH" ] && export PKG_CONFIG_PATH=/usr/local/opt/qt/lib/pkgconfig/
+sudo -E python3 setup.py install

--- a/python/python3_pyqt5/mainwindow.py
+++ b/python/python3_pyqt5/mainwindow.py
@@ -15,7 +15,7 @@ class HexEdit(QHexEdit):
         
 if __name__ == '__main__':
     app = QtWidgets.QApplication(sys.argv)
-    mainWin = HexEdit('mainwindow.py')
+    mainWin = HexEdit(sys.argv[1] if len(sys.argv) > 1 else sys.argv[0])
     mainWin.resize(600, 400)
     mainWin.move(300, 300)
     mainWin.show()

--- a/src/qhexedit.pro
+++ b/src/qhexedit.pro
@@ -23,5 +23,5 @@ Release:TARGET = qhexedit
 Debug:TARGET = qhexeditd
 
 
-unix:DESTDIR = /usr/lib
+unix:DESTDIR = /usr/local/lib
 win32:DESTDIR = ../lib


### PR DESCRIPTION
Tried building the project on OSX 10.12 Sierra and ran into several issues.

* qmake
```
./build-python-bindings.sh: line 7: /usr/lib/x86_64-linux-gnu/qt5/bin/qmake: No such file or directory
```
=> removed the absolute path (if you want to be sure to use qt5 qmake then perhaps it should validate with -v first?)

* sip include path is wrong
```
sudo python3 setup.py install
...
sip: Deprecation warning: src/qhexedit.sip:1: %Module version numbers are deprecated and ignored
sip: Unable to find file "QtCore/QtCoremod.sip"
```
=> In brew-installed pyqt5 it's at /usr/local/Cellar/pyqt/5.*/share/sip/Qt5/QtCore/QtCoremod.sip
and /usr/local/share/sip@ -> ../Cellar/pyqt/5.7.1_1/share/sip ..so did
```
cd /usr/local/share/sip; sudo ln -s Qt5/ PyQt5
```
but if this is different in other OSes perhaps setup.py should try to detect that?

* /usr/lib is not writable on OSX (System Integrity Protection, SIP, since 10.11)
```
mv -f libqhexedit.4.0.0.dylib  /usr/lib/ 
mv: rename libqhexedit.4.0.0.dylib to /usr/lib/libqhexedit.4.0.0.dylib: Operation not permitted
make: [/usr/lib/libqhexedit.4.0.0.dylib] Error 1 (ignored)
```
=> changed DESTDIR in qhexedit.pro

* wrong compiler
```
building 'qhexedit' extension
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -Isrc -I/usr/local/Cellar/qt/5.10.1/include -I/usr/local/Cellar/qt/5.10.1/include/QtCore -I/usr/local/Cellar/qt/5.10.1/include/QtGui -I/usr/local/Cellar/qt/5.10.1/include/QtWidgets -I/usr/include/qt -I/usr/include/qt/QtCore -I/usr/include/qt/QtGui -I/usr/include/qt/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/local/Cellar/sip/4.19.8_3/include -I/usr/local/include -I/usr/local/opt/openssl/include -I/usr/local/opt/sqlite/include -I/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/include/python3.6m -c build/temp.macosx-10.12-x86_64-3.6/sipqhexeditcmodule.cpp -o build/temp.macosx-10.12-x86_64-3.6/build/temp.macosx-10.12-x86_64-3.6/sipqhexeditcmodule.o
	In file included from build/temp.macosx-10.12-x86_64-3.6/sipqhexeditcmodule.cpp:7:
	In file included from build/temp.macosx-10.12-x86_64-3.6/sipAPIqhexedit.h:12:
	In file included from /usr/local/Cellar/qt/5.10.1/include/QtCore/QMetaType:1:
	In file included from /usr/local/Cellar/qt/5.10.1/include/QtCore/qmetatype.h:44:
	In file included from /usr/local/Cellar/qt/5.10.1/include/QtCore/qglobal.h:99:
	/usr/local/Cellar/qt/5.10.1/include/QtCore/qcompilerdetection.h:567:6: error: Qt requires a C++11 compiler and yours does not seem to be that.
#    error Qt requires a C++11 compiler and yours does not seem to be that.
```
=> added  self.compiler.compiler_so += ['-std=gnu++11']
  (Running python3 setup.py install with DISTUTILS_DEBUG=1 and reading distutils/command/build_ext.py helped here)

* linker doesn't find libraries
```
	ld: library not found for -lQt5Core
```
=> Perhaps sipconfig.Configuration() had .qt_framework for osx before but my brew installed pyqt5 sip version didn't so it branched into the linux condition.
Before realizing it should use the .framework files with -F option, I first tried linking against qt5 dylibs I had laying around, while it linked and ran it errored out with "QPixmap: Must construct a QGuiApplication before a QPixmap" (mentioning this in case someone googles for the error).
To get .frameworks linked, pkgconfig appeared easiest so added the function for distutils in setup.py and PKG_CONFIG_PATH in build-python-bindings.sh.

And now finally, python/python3_pyqt5/mainwindow.py executes and opens the window without errors.
