### PR TITLE
Do not reset selection when the pressed button is the right button

### DIFF
--- a/build-example.sh
+++ b/build-example.sh
@@ -1,3 +1,4 @@
+mkdir -p build
 cd build
 qmake ../example/qhexedit.pro
 make

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -812,7 +812,8 @@ void QHexEdit::mousePressEvent(QMouseEvent * event)
     qint64 cPos = cursorPosition(event->pos());
     if (cPos >= 0)
     {
-        resetSelection(cPos);
+        if (event->button() != Qt::RightButton)
+            resetSelection(cPos);
         setCursorPosition(cPos);
     }
 }


### PR DESCRIPTION
This allows users of the library to set a context menu with actions
    applying to the selection without loosing it.

This was necessary in https://github.com/sqlitebrowser/sqlitebrowser in order to create a new context menu with an option for copying the readable selection to the clipboard. See https://github.com/sqlitebrowser/sqlitebrowser/commit/a90d1b24d3a126b8549797ec5c4d1572b3e4a452

It might be of interest to others and I assume that resetting the selection in a mouse click was mainly intended for the left button.

There is also a minor change in the build script for the first time the example is built.