### PR TITLE
use 'monospace' hint to improve font guess

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -431,9 +431,12 @@ QString QHexEdit::selectedData()
 
 void QHexEdit::setFont(const QFont &font)
 {
-    QWidget::setFont(font);
-    _pxCharWidth = fontMetrics().width(QLatin1Char('2'));
-    _pxCharHeight = fontMetrics().height();
+    QFont theFont(font);
+    theFont.setStyleHint(QFont::Monospace, QFont::NoAntialias);
+    QWidget::setFont(theFont);
+    QFontMetrics metrics = fontMetrics();
+    _pxCharWidth = metrics.horizontalAdvance(QLatin1Char('2'));
+    _pxCharHeight = metrics.height();
     _pxGapAdr = _pxCharWidth / 2;
     _pxGapAdrHex = _pxCharWidth;
     _pxGapHexAscii = 2 * _pxCharWidth;


### PR DESCRIPTION
When the hardcoded font is not found, a random font is selected (on my system, it is not a fixed space font, and the metrics are wrong).

Adding `QFont::Monospace` hint will help Qt choose a better one (i.e. fixed-width) when the specified font is not present in the system.

I could have also found some font name for `Q_OS_MAC`, but in my opinion this is a better change.