### PR TITLE
Add colorization properties

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -345,6 +345,17 @@ QColor QHexEdit::addressTextColor()
     return _addressTextColor.color();
 }
 
+void QHexEdit::setNullBytesColor(const QColor &color)
+{
+    _nullBytesColor = QPen(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::nullBytesColor()
+{
+    return _nullBytesColor.color();
+}
+
 // ********************************************************************** Access to data of qhexedit
 bool QHexEdit::setData(QIODevice &iODevice)
 {
@@ -939,6 +950,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
                     r.setRect(pxPosX - _pxCharWidth, pxPosY - _pxCharHeight + _pxSelectionSub, 3*_pxCharWidth, _pxCharHeight);
                 painter.fillRect(r, c);
                 hex = _hexDataShown.mid((bPosLine + colIdx) * 2, 2);
+                if ( hex == "00") painter.setPen(_nullBytesColor);
                 painter.drawText(pxPosX, pxPosY, hexCaps()?hex.toUpper():hex);
                 pxPosX += 3*_pxCharWidth;
 

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -390,6 +390,17 @@ QColor QHexEdit::cursorReadOnlyColor()
     return _cursorReadOnlyColor;
 }
 
+void QHexEdit::setCursorTextColor(const QColor &color)
+{
+    _cursorTextColor = QColor(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::cursorTextColor()
+{
+    return _cursorTextColor;
+}
+
 // ********************************************************************** Access to data of qhexedit
 bool QHexEdit::setData(QIODevice &iODevice)
 {
@@ -1024,6 +1035,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
                 if (_blink && hasFocus()) painter.fillRect(_cursorRect, QColor(_cursorInsertOverwriteColor));
             }
 
+            painter.setPen(_cursorTextColor);
             if (_editAreaIsAscii)
             {
                 // every 2 hex there is 1 ascii

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -334,6 +334,17 @@ QColor QHexEdit::asciiSeparatorColor()
     return _asciiSeparatorColor.color();
 }
 
+void QHexEdit::setAddressTextColor(const QColor &color)
+{
+    _addressTextColor = QPen(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::addressTextColor()
+{
+    return _addressTextColor.color();
+}
+
 // ********************************************************************** Access to data of qhexedit
 bool QHexEdit::setData(QIODevice &iODevice)
 {
@@ -883,6 +894,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             for (int row=0, pxPosY = _pxCharHeight; row <= (_dataShown.size()/_bytesPerLine); row++, pxPosY +=_pxCharHeight)
             {
                 address = QString("%1").arg(_bPosFirst + row*_bytesPerLine + _addressOffset, _addrDigits, 16, QChar('0'));
+                painter.setPen(_addressTextColor);
                 painter.drawText(_pxPosAdrX - pxOfsX, pxPosY, hexCaps() ? address.toUpper() : address);
             }
         }

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -367,6 +367,17 @@ QColor QHexEdit::alphaNumericAsciiColor()
     return _alphaNumericAsciiColor.color();
 }
 
+void QHexEdit::setCursorInsertOverwriteColor(const QColor &color)
+{
+    _cursorInsertOverwriteColor = QColor(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::cursorInsertOverwriteColor()
+{
+    return _cursorInsertOverwriteColor;
+}
+
 // ********************************************************************** Access to data of qhexedit
 bool QHexEdit::setData(QIODevice &iODevice)
 {
@@ -1000,8 +1011,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             }
             else
             {
-                if (_blink && hasFocus())
-                    painter.fillRect(_cursorRect, this->palette().color(QPalette::WindowText));
+                if (_blink && hasFocus()) painter.fillRect(_cursorRect, QColor(_cursorInsertOverwriteColor));
             }
 
             if (_editAreaIsAscii)

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -356,6 +356,17 @@ QColor QHexEdit::nullBytesColor()
     return _nullBytesColor.color();
 }
 
+void QHexEdit::setAlphaNumericAsciiColor(const QColor &color)
+{
+    _alphaNumericAsciiColor = QPen(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::alphaNumericAsciiColor()
+{
+    return _alphaNumericAsciiColor.color();
+}
+
 // ********************************************************************** Access to data of qhexedit
 bool QHexEdit::setData(QIODevice &iODevice)
 {
@@ -958,8 +969,11 @@ void QHexEdit::paintEvent(QPaintEvent *event)
                 if (_asciiArea)
                 {
                     int ch = (uchar)_dataShown.at(bPosLine + colIdx);
-                    if ( ch < ' ' || ch > '~' )
+                    if ( ch < ' ' || ch > '~' ) {
                         ch = '.';
+                    } else {
+                        painter.setPen(_alphaNumericAsciiColor);
+                    }
                     r.setRect(pxPosAsciiX2, pxPosY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight);
                     painter.fillRect(r, c);
                     painter.drawText(pxPosAsciiX2, pxPosY, QChar(ch));

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -26,6 +26,7 @@ QHexEdit::QHexEdit(QWidget *parent) : QAbstractScrollArea(parent)
     _hexCaps = false;
     _dynamicBytesPerLine = false;
     _asciiSeparatorColor = QColor(Qt::gray);
+    _cursorReadOnlyColor = QColor(Qt::green);
 
     _chunks = new Chunks(this);
     _undoStack = new UndoStack(_chunks, this);
@@ -376,6 +377,17 @@ void QHexEdit::setCursorInsertOverwriteColor(const QColor &color)
 QColor QHexEdit::cursorInsertOverwriteColor()
 {
     return _cursorInsertOverwriteColor;
+}
+
+void QHexEdit::setCursorReadOnlyColor(const QColor &color)
+{
+    _cursorReadOnlyColor = QColor(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::cursorReadOnlyColor()
+{
+    return _cursorReadOnlyColor;
 }
 
 // ********************************************************************** Access to data of qhexedit
@@ -1005,9 +1017,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             // paint cursor
             if (_readOnly)
             {
-                // make the background stick out
-                QColor color = viewport()->palette().dark().color();
-                painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), color);
+                painter.fillRect(QRect(_pxCursorX - pxOfsX, _pxCursorY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight), QColor(_cursorReadOnlyColor));
             }
             else
             {

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -25,6 +25,7 @@ QHexEdit::QHexEdit(QWidget *parent) : QAbstractScrollArea(parent)
     _editAreaIsAscii = false;
     _hexCaps = false;
     _dynamicBytesPerLine = false;
+    _asciiSeparatorColor = QColor(Qt::gray);
 
     _chunks = new Chunks(this);
     _undoStack = new UndoStack(_chunks, this);
@@ -310,6 +311,17 @@ void QHexEdit::setDynamicBytesPerLine(const bool isDynamic)
 bool QHexEdit::dynamicBytesPerLine()
 {
     return _dynamicBytesPerLine;
+}
+
+void QHexEdit::setAsciiSeparatorColor(const QColor &color)
+{
+    _asciiSeparatorColor = QPen(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::asciiSeparatorColor()
+{
+    return _asciiSeparatorColor.color();
 }
 
 // ********************************************************************** Access to data of qhexedit
@@ -848,7 +860,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
         if (_asciiArea)
         {
             int linePos = _pxPosAsciiX - (_pxGapHexAscii / 2);
-            painter.setPen(Qt::gray);
+            painter.setPen(_asciiSeparatorColor);
             painter.drawLine(linePos - pxOfsX, event->rect().top(), linePos - pxOfsX, height());
         }
 

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -269,13 +269,23 @@ bool QHexEdit::overwriteMode()
 void QHexEdit::setSelectionColor(const QColor &color)
 {
     _brushSelection = QBrush(color);
-    _penSelection = QPen(Qt::white);
     viewport()->update();
 }
 
 QColor QHexEdit::selectionColor()
 {
     return _brushSelection.color();
+}
+
+void QHexEdit::setSelectionTextColor(const QColor &color)
+{
+    _penSelection = QPen(color);
+    viewport()->update();
+}
+
+QColor QHexEdit::selectionTextColor()
+{
+    return _penSelection.color();
 }
 
 bool QHexEdit::isReadOnly()

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -161,6 +161,12 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor addressTextColor READ addressTextColor WRITE setAddressTextColor)
 
+    /*! Property selection color sets (setNullBytesColor()) the
+    color of NULL bytes text. You can also read the color
+    (nullBytesColor()).
+    */
+    Q_PROPERTY(QColor nullBytesColor READ nullBytesColor WRITE setNullBytesColor)
+
 public:
     /*! Creates an instance of QHexEdit.
     \param parent Parent widget of QHexEdit.
@@ -360,6 +366,9 @@ public:
     QColor addressTextColor();
     void setAddressTextColor(const QColor &color);
 
+    QColor nullBytesColor();
+    void setNullBytesColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -428,6 +437,7 @@ private:
     bool _dynamicBytesPerLine;
     QPen _asciiSeparatorColor;
     QPen _addressTextColor;
+    QPen _nullBytesColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -167,11 +167,17 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor nullBytesColor READ nullBytesColor WRITE setNullBytesColor)
 
-    /*! Property selection color sets (alphaNumericAsciiColor()) the
+    /*! Property selection color sets (setAlphaNumericAsciiColor()) the
     color of Alphanumeric ASCII text in text area. You can also read the color
     (alphaNumericAsciiColor()).
     */
     Q_PROPERTY(QColor alphaNumericAsciiColor READ alphaNumericAsciiColor WRITE setAlphaNumericAsciiColor)
+
+    /*! Property selection color sets (setCursorInsertOverwriteColor()) the
+    color of the cursor when in insert or overwrite mode. You can also read the color
+    (cursorInsertOverwriteColor()).
+    */
+    Q_PROPERTY(QColor cursorInsertOverwriteColor READ cursorInsertOverwriteColor WRITE setCursorInsertOverwriteColor)
 
 public:
     /*! Creates an instance of QHexEdit.
@@ -378,6 +384,9 @@ public:
     QColor alphaNumericAsciiColor();
     void setAlphaNumericAsciiColor(const QColor &color);
 
+    QColor cursorInsertOverwriteColor();
+    void setCursorInsertOverwriteColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -448,6 +457,7 @@ private:
     QPen _addressTextColor;
     QPen _nullBytesColor;
     QPen _alphaNumericAsciiColor;
+    QColor _cursorInsertOverwriteColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -133,6 +133,12 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor selectionColor READ selectionColor WRITE setSelectionColor)
 
+    /*! Property selection color sets (setSelectionTextColor()) the foreground
+    color of the selected text. You can also read the color
+    (selectionTextColor()).
+    */
+    Q_PROPERTY(QColor selectionTextColor READ selectionTextColor WRITE setSelectionTextColor)
+
     /*! Property readOnly sets (setReadOnly()) or gets (isReadOnly) the mode
     in which the editor works. In readonly mode the the user can only navigate
     through the data and select data; modifying is not possible. This
@@ -148,6 +154,7 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     (asciiSeparatorColor()).
     */
     Q_PROPERTY(QColor asciiSeparatorColor READ asciiSeparatorColor WRITE setAsciiSeparatorColor)
+
 
 
 public:
@@ -342,6 +349,9 @@ public:
 
     QColor asciiSeparatorColor();
     void setAsciiSeparatorColor(const QColor &color);
+
+    QColor selectionTextColor();
+    void setSelectionTextColor(const QColor &color);
 
 protected:
     // Handle events

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -179,6 +179,12 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor cursorInsertOverwriteColor READ cursorInsertOverwriteColor WRITE setCursorInsertOverwriteColor)
 
+    /*! Property selection color sets (setCursorReadOnlyColor()) the
+    color of the cursor when in read-only mode. You can also read the color
+    (cursorReadOnlyColor()).
+    */
+    Q_PROPERTY(QColor cursorReadOnlyColor READ cursorReadOnlyColor WRITE setCursorReadOnlyColor)
+
 public:
     /*! Creates an instance of QHexEdit.
     \param parent Parent widget of QHexEdit.
@@ -387,6 +393,9 @@ public:
     QColor cursorInsertOverwriteColor();
     void setCursorInsertOverwriteColor(const QColor &color);
 
+    QColor cursorReadOnlyColor();
+    void setCursorReadOnlyColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -458,6 +467,7 @@ private:
     QPen _nullBytesColor;
     QPen _alphaNumericAsciiColor;
     QColor _cursorInsertOverwriteColor;
+    QColor _cursorReadOnlyColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -185,6 +185,12 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor cursorReadOnlyColor READ cursorReadOnlyColor WRITE setCursorReadOnlyColor)
 
+    /*! Property selection color sets (setCursorTextColor()) the foreground
+    text color of the cursor. You can also read the color
+    (cursorTextColor()).
+    */
+    Q_PROPERTY(QColor cursorTextColor READ cursorTextColor WRITE setCursorTextColor)
+
 public:
     /*! Creates an instance of QHexEdit.
     \param parent Parent widget of QHexEdit.
@@ -396,6 +402,9 @@ public:
     QColor cursorReadOnlyColor();
     void setCursorReadOnlyColor(const QColor &color);
 
+    QColor cursorTextColor();
+    void setCursorTextColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -468,6 +477,7 @@ private:
     QPen _alphaNumericAsciiColor;
     QColor _cursorInsertOverwriteColor;
     QColor _cursorReadOnlyColor;
+    QColor _cursorTextColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -167,6 +167,12 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor nullBytesColor READ nullBytesColor WRITE setNullBytesColor)
 
+    /*! Property selection color sets (alphaNumericAsciiColor()) the
+    color of Alphanumeric ASCII text in text area. You can also read the color
+    (alphaNumericAsciiColor()).
+    */
+    Q_PROPERTY(QColor alphaNumericAsciiColor READ alphaNumericAsciiColor WRITE setAlphaNumericAsciiColor)
+
 public:
     /*! Creates an instance of QHexEdit.
     \param parent Parent widget of QHexEdit.
@@ -369,6 +375,9 @@ public:
     QColor nullBytesColor();
     void setNullBytesColor(const QColor &color);
 
+    QColor alphaNumericAsciiColor();
+    void setAlphaNumericAsciiColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -438,6 +447,7 @@ private:
     QPen _asciiSeparatorColor;
     QPen _addressTextColor;
     QPen _nullBytesColor;
+    QPen _alphaNumericAsciiColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -143,6 +143,13 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     /*! Set the font of the widget. Please use fixed width fonts like Mono or Courier.*/
     Q_PROPERTY(QFont font READ font WRITE setFont)
 
+    /*! Property selection color sets (setAsciiSeparatorColor()) the
+    color of the ASCII text line separator. You can also read the color
+    (asciiSeparatorColor()).
+    */
+    Q_PROPERTY(QColor asciiSeparatorColor READ asciiSeparatorColor WRITE setAsciiSeparatorColor)
+
+
 public:
     /*! Creates an instance of QHexEdit.
     \param parent Parent widget of QHexEdit.
@@ -333,6 +340,9 @@ public:
     QColor selectionColor();
     void setSelectionColor(const QColor &color);
 
+    QColor asciiSeparatorColor();
+    void setAsciiSeparatorColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -399,6 +409,7 @@ private:
     bool _readOnly;
     bool _hexCaps;
     bool _dynamicBytesPerLine;
+    QPen _asciiSeparatorColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -155,7 +155,11 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     */
     Q_PROPERTY(QColor asciiSeparatorColor READ asciiSeparatorColor WRITE setAsciiSeparatorColor)
 
-
+    /*! Property selection color sets (setAddressTextColor()) the
+    color of the Addresses Offset text. You can also read the color
+    (addressTextColor()).
+    */
+    Q_PROPERTY(QColor addressTextColor READ addressTextColor WRITE setAddressTextColor)
 
 public:
     /*! Creates an instance of QHexEdit.
@@ -353,6 +357,9 @@ public:
     QColor selectionTextColor();
     void setSelectionTextColor(const QColor &color);
 
+    QColor addressTextColor();
+    void setAddressTextColor(const QColor &color);
+
 protected:
     // Handle events
     void keyPressEvent(QKeyEvent *event);
@@ -420,6 +427,7 @@ private:
     bool _hexCaps;
     bool _dynamicBytesPerLine;
     QPen _asciiSeparatorColor;
+    QPen _addressTextColor;
 
     // other variables
     bool _editAreaIsAscii;                      // flag about the ascii mode edited


### PR DESCRIPTION
Hi, I've added more colorization options to qhexedit2 using properties and replaced color's hard-coded values:

New properties:
- READ asciiSeparatorColor WRITE setAsciiSeparatorColor
- READ addressTextColor WRITE setAddressTextColor
- READ nullBytesColor WRITE setNullBytesColor
- READ alphaNumericAsciiColor WRITE setAlphaNumericAsciiColor
- READ cursorInsertOverwriteColor WRITE setCursorInsertOverwriteColor
- READ cursorReadOnlyColor WRITE setCursorReadOnlyColor
- READ cursorTextColor WRITE setCursorTextColor

Changed properties:
- READ selectionColor WRITE setSelectionColor

![image](https://user-images.githubusercontent.com/74644600/107764168-a4be0200-6d27-11eb-82d1-73b809640fe2.png)

Please review, and let me know if any issues.