### PR TITLE
Fix: Clang detach temporary

### DIFF
--- a/src/chunks.cpp
+++ b/src/chunks.cpp
@@ -255,7 +255,7 @@ bool Chunks::removeAt(qint64 pos)
 
 char Chunks::operator[](qint64 pos)
 {
-    return data(pos, 1)[0];
+    return data(pos, 1).at(0);
 }
 
 qint64 Chunks::pos()

--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -768,9 +768,9 @@ void QHexEdit::keyPressEvent(QKeyEvent *event)
             /* Hex and ascii input */
             int key;
             if (_editAreaIsAscii)
-                key = (uchar)event->text()[0].toLatin1();
+                key = (uchar)event->text().at(0).toLatin1();
             else
-                key = int(event->text()[0].toLower().toLatin1());
+                key = int(event->text().at(0).toLower().toLatin1());
 
             if ((((key >= '0' && key <= '9') || (key >= 'a' && key <= 'f')) && _editAreaIsAscii == false)
                 || (key >= ' ' && _editAreaIsAscii))


### PR DESCRIPTION
Split from #132. Fix only the detachment of the temp vars.