### PR TITLE
setup.py: fix pyqt_sip_dir on modern Linux distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,14 @@ import sipconfig
 
 cfg = sipconfig.Configuration()
 pyqt_sip_dir = cfg.default_sip_dir
+for p in (os.path.join(pyqt_sip_dir, "PyQt5"),
+          os.path.join(pyqt_sip_dir, "PyQt5-3"),
+          os.path.join(pyqt_sip_dir, "PyQt4"),
+          pyqt_sip_dir,
+          os.path.join(cfg.default_mod_dir, "PyQt5", "bindings")):
+    if os.path.exists(os.path.join(p, "QtCore", "QtCoremod.sip")):
+        pyqt_sip_dir = p
+        break
 
 try:
     import PyQt5


### PR DESCRIPTION
QtCore/QtCoremod.sip may be installed to:
/usr/lib/python3.9/site-packages/PyQt5/bindings/QtCore/QtCoremod.sip
See also: https://github.com/qgis/QGIS/blob/master/cmake/FindPyQt5.py

Closes: https://bugs.gentoo.org/820473