### PR TITLE
Do not show the last blank line

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -908,7 +908,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
         if (_addressArea)
         {
             QString address;
-            for (int row=0, pxPosY = _pxCharHeight; row <= (_dataShown.size()/_bytesPerLine); row++, pxPosY +=_pxCharHeight)
+            for (int row=0, pxPosY = _pxCharHeight; row < (_dataShown.size()/_bytesPerLine); row++, pxPosY +=_pxCharHeight)
             {
                 address = QString("%1").arg(_bPosFirst + row*_bytesPerLine + _addressOffset, _addrDigits, 16, QChar('0'));
                 painter.setPen(QPen(_addressFontColor));


### PR DESCRIPTION
The last blank line, containing only the address, is not informative. It increases the height of the widget. I think it should not be displayed in the widget.