### PR TITLE
Enable customization of default ASCII character

### DIFF
--- a/src/qhexedit.cpp
+++ b/src/qhexedit.cpp
@@ -33,6 +33,7 @@ QHexEdit::QHexEdit(QWidget *parent) : QAbstractScrollArea(parent)
     , _addressWidth(4)
     , _asciiArea(true)
     , _bytesPerLine(16)
+    , _defaultChar('.')
     , _hexCharsInLine(47)
     , _highlighting(true)
     , _overwriteMode(true)
@@ -152,6 +153,20 @@ void QHexEdit::setBytesPerLine(int count)
 int QHexEdit::bytesPerLine()
 {
     return _bytesPerLine;
+}
+
+char QHexEdit::defaultChar()
+{
+    return _defaultChar;
+}
+
+void QHexEdit::setDefaultChar(char defaultChar)
+{
+    _defaultChar = defaultChar;
+
+    adjust();
+    setCursorPosition(_cursorPosition);
+    viewport()->update();
 }
 
 void QHexEdit::setCursorPosition(qint64 position)
@@ -941,7 +956,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
 
                     int ch = (uchar)_dataShown.at(bPosLine + colIdx);
                     if ( ch < ' ' || ch > '~' )
-                        ch = '.';
+                        ch = _defaultChar;
                     rect.setRect(pxPosAsciiX2, pxPosY - _pxCharHeight + _pxSelectionSub, _pxCharWidth, _pxCharHeight);
                     painter.fillRect(rect, asciiArea.areaStyle());
                     painter.drawText(pxPosAsciiX2, pxPosY, QChar(ch));
@@ -978,7 +993,7 @@ void QHexEdit::paintEvent(QPaintEvent *event)
             // every 2 hex there is 1 ascii
             int ch = (uchar)_dataShown.at(hexPos / 2);
             if (ch < ' ' || ch > '~')
-                ch = '.';
+                ch = _defaultChar;
 
             painter.drawText(_pxCursorX - pxOfsX, _pxCursorY, QChar(ch));
         }
@@ -1176,7 +1191,7 @@ QString QHexEdit::toReadable(const QByteArray &ba)
                 hexStr.append(" ").append(ba.mid(i+j, 1).toHex());
                 char ch = ba[i + j];
                 if ((ch < 0x20) || (ch > 0x7e))
-                        ch = '.';
+                        ch = _defaultChar;
                 ascStr.append(QChar(ch));
             }
         }

--- a/src/qhexedit.h
+++ b/src/qhexedit.h
@@ -102,6 +102,10 @@ class QHEXEDIT_API QHexEdit : public QAbstractScrollArea
     /*! Set and get bytes number per line.*/
     Q_PROPERTY(int bytesPerLine READ bytesPerLine WRITE setBytesPerLine)
 
+    /*! Set and get character to display when outside the printable range.
+    */
+    Q_PROPERTY(int defaultChar READ defaultChar WRITE setDefaultChar)
+
     /*! Property cursorPosition sets or gets the position of the editor cursor
     in QHexEdit. Every byte in data has two cursor positions: the lower and upper
     Nibble. Maximum cursor position is factor two of data.size().
@@ -328,6 +332,9 @@ public:
     int bytesPerLine();
     void setBytesPerLine(int count);
 
+    char defaultChar();
+    void setDefaultChar(char defaultChar);
+
     qint64 cursorPosition();
     void setCursorPosition(qint64 position);
 
@@ -405,6 +412,7 @@ private:
     bool _asciiArea;
     qint64 _addressOffset;
     int _bytesPerLine;
+    char _defaultChar;
     int _hexCharsInLine;
     bool _highlighting;
     bool _overwriteMode;


### PR DESCRIPTION
Previously, the character used when a byte falls outside of the ASCII printable range was hardcoded to a period (`.`). This PR adds the property `defaultChar` to enable its customization.