### PR TITLE
Fixed naming the shared library for debug and release builds.

### DIFF
--- a/src/qhexedit.pro
+++ b/src/qhexedit.pro
@@ -19,9 +19,12 @@ SOURCES = \
     commands.cpp \
     color_manager.cpp
 
-Release:TARGET = qhexedit
-Debug:TARGET = qhexeditd
-
+CONFIG += debug_and_release
+CONFIG(debug, debug|release) {
+    TARGET = qhexeditd
+} else {
+    TARGET = qhexedit
+}
 
 unix {
     # Allows users to specify parameters when running qmake


### PR DESCRIPTION
Seems to work now. Adding the `debug_and_release` token to `CONFIG` might impact other workflows, so it needs to be tested on your configuration. But I think it is an improvement since it keeps all of the intermediate artifacts (object files, etc.) in one build configuration separate from the other configurations.

However, I discovered that if you already have a custom build directory which switches on `{BuildConfig:name}` in Qt Creator settings, as I do, you can also leave it out. But you need the `CONFIG(debug,debug|release)` switch to keep one `TARGET` specification from overwriting the other.

If you want to try out the `OBJECTS_DIR = ./.obj`, etc. suggestion, I can create another pull request for that.